### PR TITLE
feat: Add support for multiple Instagram package

### DIFF
--- a/app/src/main/java/ps/reso/instaeclipse/Xposed/Module.java
+++ b/app/src/main/java/ps/reso/instaeclipse/Xposed/Module.java
@@ -8,6 +8,10 @@ import android.os.Build;
 
 import org.luckypray.dexkit.DexKitBridge;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.IXposedHookZygoteInit;
 import de.robv.android.xposed.XC_MethodHook;
@@ -41,6 +45,25 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
     public static ClassLoader hostClassLoader;
     private static String moduleSourceDir;
     private static String moduleLibDir;
+
+    private static final Set<String> TARGET_PACKAGES = new HashSet<>(Arrays.asList(
+            CommonUtils.IG_PACKAGE_NAME,
+            "com.myinsta.android",
+            "cc.honista.app",
+            "com.instaprime.android",
+            "com.instafel.android",
+            "com.instadm.android",
+            "com.dfistagram.android",
+            "com.Instander.android",
+            "com.aero.instagram",
+            "com.instander.android",
+            "com.instapro.android",
+            "com.instaflow.android",
+            "com.instagram1.android",
+            "com.instagram2.android",
+            "com.instagramclone.android",
+            "com.instaclone.android"
+    ));
 
     // for dev usage
     /*
@@ -102,27 +125,27 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
             }
         }
 
-        // Hook into Instagram
-        if (lpparam.packageName.equals(CommonUtils.IG_PACKAGE_NAME)) {
+        // Hook into Instagram and its mods
+        if (TARGET_PACKAGES.contains(lpparam.packageName)) {
             try {
                 if (dexKitBridge == null) {
                     // Load the .so file from your module (if not already loaded)
                     System.load(moduleLibDir + "/libdexkit.so");
                     // XposedBridge.log("libdexkit.so loaded successfully.");
 
-                    // Initialize DexKitBridge with Instagram's APK
+                    // Initialize DexKitBridge with the target app's APK
                     dexKitBridge = DexKitBridge.create(lpparam.appInfo.sourceDir);
-                    // XposedBridge.log("DexKitBridge initialized with Instagram's APK: " + lpparam.appInfo.sourceDir);
+                    // XposedBridge.log("DexKitBridge initialized with " + lpparam.packageName + "'s APK: " + lpparam.appInfo.sourceDir);
                 }
 
-                // Use Instagram's ClassLoader
+                // Use the target app's ClassLoader
                 hostClassLoader = lpparam.classLoader;
 
-                // Call the method to hook Instagram
+                // Call the method to hook the app
                 hookInstagram(lpparam);
 
             } catch (Exception e) {
-                XposedBridge.log("(InstaEclipse): Failed to initialize DexKitBridge for Instagram: " + e.getMessage());
+                XposedBridge.log("(InstaEclipse): Failed to initialize DexKitBridge for " + lpparam.packageName + ": " + e.getMessage());
             }
         }
     }
@@ -144,7 +167,7 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
                 @Override
                 protected void afterHookedMethod(MethodHookParam param) {
 
-                    XposedBridge.log("InstaEclipse: Settings loaded via Application.attach");
+                    XposedBridge.log("InstaEclipse: Settings loaded via Application.attach for " + lpparam.packageName);
 
                     // Setup context, preferences
                     Context context = (Context) param.args[0];
@@ -155,7 +178,7 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
                     UIHookManager instagramUI = new UIHookManager();
                     instagramUI.mainActivity(hostClassLoader);
 
-                    XposedBridge.log("(InstaEclipse): Instagram package detected. Starting feature hooks...");
+                    XposedBridge.log("(InstaEclipse): " + lpparam.packageName + " package detected. Starting feature hooks...");
 
                     Interceptor interceptor = new Interceptor();
 
@@ -263,7 +286,7 @@ public class Module implements IXposedHookLoadPackage, IXposedHookZygoteInit {
             });
 
         } catch (Exception e) {
-            XposedBridge.log("(InstaEclipse): Failed to hook Instagram: " + e.getMessage());
+            XposedBridge.log("(InstaEclipse): Failed to hook " + lpparam.packageName + ": " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
The module will now hook into the following packages:
Instagram package names
com.myinsta.android
cc.honista.app
com.instaprime.android
com.instafel.android
com.instadm.android
com.dfistagram.android
com.Instander.android
com.aero.instagram
com.instander.android
com.instapro.android
com.instaflow.android
com.instagram1.android
com.instagram2.android
com.instagramclone.android
com.instaclone.android